### PR TITLE
fixes #1: ensure unix line endings for script files in unix packages

### DIFF
--- a/src/main/assemble/distribution.xml
+++ b/src/main/assemble/distribution.xml
@@ -40,6 +40,7 @@
             <directory>${project.basedir}/src/main/distribution</directory>
             <outputDirectory>/</outputDirectory>
             <fileMode>0755</fileMode>
+            <lineEnding>unix</lineEnding>
             <includes>
                 <include>bin/${project.artifactId}</include>
             </includes>

--- a/src/main/assemble/installers/linux/preMake.groovy
+++ b/src/main/assemble/installers/linux/preMake.groovy
@@ -34,3 +34,9 @@ ant.copy(
         filter(token: "organization.name", value: project.organization.name)
     }
 }
+
+ant.fixcrlf(
+    srcdir: "${filesDirectory}",
+    eol: "unix",
+    eof: "remove"
+)


### PR DESCRIPTION
Fixed assembly configuration and pre-packaging script to ensure unix line endings for shell scripts that will end up in the unix packages. 

Installing a locally built debian package worked fine (including autostart), but since I build on linux, this is not the ultimate test (which would be building on a windows machine).
